### PR TITLE
Added a script for latexdiff and a makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -156,7 +156,7 @@ PDFA=pdfa-gs-converter
 		(test -d $(PDFA) && make -C $(PDFA) all &>/dev/null && echo $(PDFA)/$(PDFA).sh) ||\
 		(test -d lapesd-thesis/$(PDFA) && make -C lapesd-thesis/$(PDFA) &>/dev/null &&\
 			echo lapesd-thesis/$(PDFA)/$(PDFA).sh) ||\
-		((test -f $(PDFA.sh) || curl -Lo $(PDFA).sh $(PDFA_URL)) && echo bash ./$(PDFA).sh) ||\
+		((test -f $(PDFA).sh || curl -Lo $(PDFA).sh $(PDFA_URL)) && echo bash ./$(PDFA).sh) ||\
 		(echo $(PDFA).sh)\
 	); \
 	echo $$PDFA_CMD "$<" "$@" "$(DIM)"; \

--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,11 @@ srcs=$(wildcard *.tex) $(wildcard *.bib)
 svgs=$(wildcard imgs/*.svg)
 pdfs=$(svgs:.svg=.pdf)
 
-basename:=$(shell (grep -rE '\\documentclass.*lapesd-thesis' | cut -d : -f 1 | grep -E '.tex$$' | xargs -n 1 bash -c 'echo $$(echo $$@ | wc -c):$$@' a | sed -E 's/^([0-9]):/00\1:/' | sed -E 's/^([0-9][0-9]):/0\1:/' | sort -u | head -n 1 | sed -E 's/^[0-9]+:(.*).tex$$/\1/g' > basename.make.log && test "$$(cat basename.make.log)" != "001:" && cat basename.make.log && rm -f basename.make.log)  || echo main)
+ifndef MAIN_FILE
+	basename:=$(shell (grep -rE '\\documentclass.*lapesd-thesis' | cut -d : -f 1 | grep -E '.tex$$' | xargs -n 1 bash -c 'echo $$(echo $$@ | wc -c):$$@' a | sed -E 's/^([0-9]):/00\1:/' | sed -E 's/^([0-9][0-9]):/0\1:/' | sort -u | head -n 1 | sed -E 's/^[0-9]+:(.*).tex$$/\1/g' > basename.make.log && test "$$(cat basename.make.log)" != "001:" && cat basename.make.log && rm -f basename.make.log)  || echo main)
+else
+	basename:=$(MAIN_FILE)
+endif
 
 RED=$(shell tput sgr0 ; tput setab 1 ; tput setaf 7)
 YELLOW=$(shell tput sgr0 ; tput setab 3 ; tput setaf 0)
@@ -40,7 +44,7 @@ imgs: $(pdfs)
 .SECONDARY: $(basename).aux $(basename).blg $(basename).ilg $(basename).pdf
 
 clean:
-	rm -fr *.64 main-logo.pdf _minted-* *.aux *.bbl *.blg *.brf *.out *.synctex.gz *.log "$(basename).pdf" "$(basename).pdfa.pdf" *.idx *.ilg *.ind *.lof *.lot *.lol *.loalgorithm *.glsdefs *.xdy *.toc *.acn *.glo *.ist *.prv *.fls *.fdb_latexmk _region*  *~ auto imgs/*.tmp.pdf {imgs,plots}/*-eps-converted-to.pdf;
+	rm -fr *.64 $(basename)-logo.pdf _minted-* *.aux *.bbl *.blg *.brf *.out *.synctex.gz *.log "$(basename).pdf" "$(basename).pdfa.pdf" *.idx *.ilg *.ind *.lof *.lot *.lol *.loalgorithm *.glsdefs *.xdy *.toc *.acn *.glo *.ist *.prv *.fls *.fdb_latexmk _region*  *~ auto imgs/*.tmp.pdf {imgs,plots}/*-eps-converted-to.pdf;
 
 
 ###################################################
@@ -152,7 +156,7 @@ PDFA=pdfa-gs-converter
 		(test -d $(PDFA) && make -C $(PDFA) all &>/dev/null && echo $(PDFA)/$(PDFA).sh) ||\
 		(test -d lapesd-thesis/$(PDFA) && make -C lapesd-thesis/$(PDFA) &>/dev/null &&\
 			echo lapesd-thesis/$(PDFA)/$(PDFA).sh) ||\
-		((test -f $(PDFA).sh || curl -Lo $(PDFA).sh $(PDFA_URL)) && echo bash ./$(PDFA).sh) ||\
+		((test -f $(PDFA.sh) || curl -Lo $(PDFA).sh $(PDFA_URL)) && echo bash ./$(PDFA).sh) ||\
 		(echo $(PDFA).sh)\
 	); \
 	echo $$PDFA_CMD "$<" "$@" "$(DIM)"; \

--- a/git_latexdiff_branch.sh
+++ b/git_latexdiff_branch.sh
@@ -1,0 +1,29 @@
+#!/bin/sh
+repo_path=.
+old_main_file=main.tex
+new_main_file=main.tex
+temporary_dir=$repo_path/tmp
+mkdir $temporary_dir
+
+#Git archive does not compress submodules!
+git archive --format=tar.gz $1 > $temporary_dir/old_project.tar.gz
+tar -xzvf $temporary_dir/old_project.tar.gz -C $temporary_dir/
+rm $temporary_dir/old_project.tar.gz
+
+#These flags are for: highlight type; consider "include" files; consider
+#citations spaces; consider citations marks; and put everything from every file
+#into a single one.
+latexdiff -t CFONT --append-safecmd=include --allow-spaces --disable-citation-markup $temporary_dir/$old_main_file $repo_path/$new_main_file --flatten > $repo_path/diff.tex
+
+# This is specific for my project. For a different project this has to be
+# CHANGED
+#IMPORTANT: THIS SCRIPT DOES NOT SUPPORT SUBMODULES! As a workaround you can put the
+#diff file directly into the newer version of your repository and use already
+#fetched submodules.
+make MAIN_FILE=diff clean; make MAIN_FILE=diff
+mv $repo_path/diff.pdf $temporary_dir/
+make MAIN_FILE=diff clean
+mv $temporary_dir/diff.pdf $repo_path/
+
+rm -r $temporary_dir
+rm diff.tex


### PR DESCRIPTION
# Overview

This PR has the goal to introduce [latexdiff](https://ctan.org/pkg/latexdiff?lang=en) to lapesd-thesis. Latexdiff may improve revisions by advisors and increase productivity for the project. It produces a `pdf` file with highlights for every modification. In the following items, it is described in more detail the contributions of this PR

* **Latexdiff script**
A new script was added to use latexdiff on the project. The script will create a temporary directory to put all files from a specific commit or branch; use latexdiff on the current branch and the one from the temporary directory; compile the output (`diff.tex`) from latexdiff, which produces a `diff.pdf`
* **Makefile** 
To consider a compilation with another main file, it was added a makefile flag `MAIN_FILE`. This is paramount to compile the `diff` file from latexdiff. Maybe there may be a better way to do it.
# Limitations

* **Overview:**
Unfortunately, the script has some limitations. First, the script does not consider submodules. To the best of my knowledge, there are no commands from `git` that get a branch with all its files and submodules. Therefore, there is no simple way to use submodules dynamically with latexdiff. To solve this, the script uses the submodules already loaded in the current branch (outside of the temporary directory). The `diff.tex` is generated using the flag `flatten`, which joins into a single file all sections from the main file. Thus, the compilation outside the temporary directory does not impact the content.
* **Latexdiff:** 
Its important to note that latexdiff has some limitations for citations and bibliography, which is solved by the script with the flags `--allow-spaces --disable-citation-markup`. Hence, when new citations appear, they are detected by latexdiff inside common text but at the references section there is no highlight of newly added citations. 
